### PR TITLE
implemented tickets: 471, 473, 474

### DIFF
--- a/packages/plugin-polygon-zkevm/src/actions/estimateZkNonce.ts
+++ b/packages/plugin-polygon-zkevm/src/actions/estimateZkNonce.ts
@@ -1,0 +1,253 @@
+import {
+  type Action,
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  type HandlerCallback,
+  type Content,
+  logger,
+  ModelType,
+  composePromptFromState,
+} from '@elizaos/core';
+import { z } from 'zod';
+import { JsonRpcProvider, isAddress } from 'ethers';
+import { extractAddressForZkNonceTemplate } from '../templates'; // Import the new template
+
+// Helper to convert hex string (e.g., "0x1a") to decimal string (e.g., "26")
+const hexToDecimalString = (hexString: string): string => {
+  return BigInt(hexString).toString();
+};
+
+interface EthGetTransactionCountResponse {
+  result?: string; // Hex string like "0x1a"
+  error?: { message: string };
+}
+
+export const estimateZkNonceAction: Action = {
+  name: 'ESTIMATE_TRANSACTION_ZK_COUNTER',
+  similes: [
+    'GET_ZKNONCE',
+    'FETCH_ACCOUNT_ZK_COUNTER',
+    'GET_NEXT_ZKEVM_NONCE',
+    'WHAT_IS_THE_ZK_NONCE_FOR_ADDRESS',
+  ],
+  description: 'Estimates the next zkCounter (nonce) for a given address on Polygon zkEVM.',
+
+  validate: async (runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<boolean> => {
+    const alchemyApiKey = runtime.getSetting('ALCHEMY_API_KEY') || process.env.ALCHEMY_API_KEY;
+    const zkevmRpcUrl = runtime.getSetting('ZKEVM_RPC_URL') || process.env.ZKEVM_RPC_URL;
+
+    if (!alchemyApiKey && !zkevmRpcUrl) {
+      logger.warn(
+        '[estimateZkNonceAction] Neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured.'
+      );
+      return false;
+    }
+    // Further validation for address presence can be implicitly handled by the handler's LLM call.
+    // If LLM can't find an address, the handler will error out.
+    logger.info('[estimateZkNonceAction] Validation passed: Sufficient configuration found.');
+    return true;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state: State, // state is needed for composePromptFromState
+    _options?: { [key: string]: unknown },
+    callback?: HandlerCallback
+  ): Promise<Content> => {
+    logger.info('[estimateZkNonceAction] Handler called.');
+
+    const alchemyApiKey = runtime.getSetting('ALCHEMY_API_KEY') || process.env.ALCHEMY_API_KEY;
+    const zkevmRpcUrlSetting = runtime.getSetting('ZKEVM_RPC_URL') || process.env.ZKEVM_RPC_URL;
+    let addressInput: { address?: string; error?: string } | null = null;
+
+    try {
+      addressInput = (await runtime.useModel(ModelType.OBJECT_LARGE, {
+        prompt: composePromptFromState({
+          state,
+          template: extractAddressForZkNonceTemplate,
+        }),
+      })) as { address?: string; error?: string };
+
+      logger.debug('[estimateZkNonceAction] Parsed LLM parameters:', addressInput);
+
+      if (addressInput?.error) {
+        throw new Error(`LLM extraction error: ${addressInput.error}`);
+      }
+      if (!addressInput?.address || !isAddress(addressInput.address)) {
+        throw new Error('Invalid or missing Ethereum address extracted by LLM.');
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(
+        `[estimateZkNonceAction] Failed to extract or validate address: ${errorMessage}`
+      );
+      // It's important to still call the callback with the error if provided
+      const errorContent: Content = {
+        text: `Failed to get zkNonce: ${errorMessage}`,
+        actions: ['ESTIMATE_TRANSACTION_ZK_COUNTER'],
+        data: { error: errorMessage },
+      };
+      if (callback) {
+        await callback(errorContent);
+      }
+      throw new Error(`Failed to get zkNonce: ${errorMessage}`);
+    }
+
+    const targetAddress = addressInput.address;
+    let nonceHex: string | null = null;
+    let methodUsed: string | null = null;
+    const errorMessages: string[] = [];
+
+    // 1. Attempt to use Alchemy API
+    if (alchemyApiKey) {
+      try {
+        logger.info(`[estimateZkNonceAction] Attempting Alchemy API for address: ${targetAddress}`);
+        const alchemyUrl = `https://polygonzkevm-mainnet.g.alchemy.com/v2/${alchemyApiKey}`;
+        const requestBody = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_getTransactionCount',
+          params: [targetAddress, 'pending'],
+        };
+
+        const response = await fetch(alchemyUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Alchemy API request failed: ${response.status} ${response.statusText}`);
+        }
+        const data = (await response.json()) as EthGetTransactionCountResponse;
+
+        if (data.error) {
+          throw new Error(`Alchemy API error: ${data.error.message}`);
+        }
+        if (typeof data.result === 'string') {
+          nonceHex = data.result;
+          methodUsed = 'Alchemy API';
+          logger.info(
+            `[estimateZkNonceAction] Nonce from Alchemy for ${targetAddress}: ${nonceHex}`
+          );
+        } else {
+          throw new Error('Alchemy API returned invalid or missing nonce result.');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`[estimateZkNonceAction] Error using Alchemy API: ${errorMessage}`);
+        errorMessages.push(`Alchemy API failed: ${errorMessage}`);
+      }
+    }
+
+    // 2. Fallback to JSON-RPC
+    if (nonceHex === null && zkevmRpcUrlSetting) {
+      try {
+        logger.info(`[estimateZkNonceAction] Attempting JSON-RPC for address: ${targetAddress}`);
+        const provider = new JsonRpcProvider(zkevmRpcUrlSetting);
+        // eth_getTransactionCount returns the count as a hex string
+        const resultHex = await provider.send('eth_getTransactionCount', [
+          targetAddress,
+          'pending',
+        ]);
+
+        if (typeof resultHex === 'string' && /^0x[0-9a-fA-F]+$/.test(resultHex)) {
+          nonceHex = resultHex;
+          methodUsed = 'JSON-RPC';
+          logger.info(`[estimateZkNonceAction] Nonce from RPC for ${targetAddress}: ${nonceHex}`);
+        } else {
+          throw new Error('JSON-RPC returned invalid or missing nonce result.');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`[estimateZkNonceAction] Error using JSON-RPC: ${errorMessage}`);
+        errorMessages.push(`JSON-RPC failed: ${errorMessage}`);
+      }
+    }
+
+    // Handle result
+    if (nonceHex !== null && methodUsed) {
+      const decimalNonce = hexToDecimalString(nonceHex);
+      const responseText = `The next zkCounter (nonce) for address ${targetAddress} is ${decimalNonce} (via ${methodUsed}).`;
+      const responseContent: Content = {
+        text: responseText,
+        actions: ['ESTIMATE_TRANSACTION_ZK_COUNTER'],
+        data: {
+          address: targetAddress,
+          zkNonceHex: nonceHex,
+          zkNonceDecimal: decimalNonce,
+          source: methodUsed,
+          network: 'polygon-zkevm',
+          timestamp: Date.now(),
+        },
+      };
+      if (callback) {
+        await callback(responseContent);
+      }
+      return responseContent;
+    } else {
+      const comprehensiveErrorMessage = `Failed to estimate zkCounter for ${targetAddress}. Errors: ${errorMessages.join('; ')}`;
+      logger.error(`[estimateZkNonceAction] ${comprehensiveErrorMessage}`);
+      const errorContent: Content = {
+        text: comprehensiveErrorMessage,
+        actions: ['ESTIMATE_TRANSACTION_ZK_COUNTER'],
+        data: {
+          error: comprehensiveErrorMessage,
+          address: targetAddress,
+          details: errorMessages,
+        },
+      };
+      if (callback) {
+        await callback(errorContent);
+      }
+      throw new Error(comprehensiveErrorMessage);
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: 'user1',
+        content: {
+          text: 'What is the next zkCounter for address 0x123abc...def456 on Polygon zkEVM?',
+        },
+      },
+      {
+        name: 'assistant1',
+        content: {
+          text: 'The next zkCounter (nonce) for address 0x123abc...def456 is 5 (via Alchemy API).',
+          actions: ['ESTIMATE_TRANSACTION_ZK_COUNTER'],
+          data: {
+            address: '0x123abc...def456',
+            zkNonceHex: '0x5',
+            zkNonceDecimal: '5',
+            source: 'Alchemy API',
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: 'user2',
+        content: {
+          text: 'Get zk-nonce for 0x789xyz...abc123',
+        },
+      },
+      {
+        name: 'assistant2',
+        content: {
+          text: 'The next zkCounter (nonce) for address 0x789xyz...abc123 is 0 (via JSON-RPC).',
+          actions: ['ESTIMATE_TRANSACTION_ZK_COUNTER'],
+          data: {
+            address: '0x789xyz...abc123',
+            zkNonceHex: '0x0',
+            zkNonceDecimal: '0',
+            source: 'JSON-RPC',
+          },
+        },
+      },
+    ],
+  ],
+};

--- a/packages/plugin-polygon-zkevm/src/actions/getExitRoots.ts
+++ b/packages/plugin-polygon-zkevm/src/actions/getExitRoots.ts
@@ -1,0 +1,241 @@
+import {
+  type Action,
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  type HandlerCallback,
+  type Content,
+  logger,
+} from '@elizaos/core';
+import { z } from 'zod';
+import { JsonRpcProvider } from 'ethers';
+
+// Helper function to validate 32-byte hex strings
+const isValidHex32Bytes = (hex: string): boolean => {
+  return typeof hex === 'string' && /^0x[a-fA-F0-9]{64}$/.test(hex);
+};
+
+// Define the expected structure of the batch object from the RPC call
+interface ZkEvmBatch {
+  number: string;
+  timestamp: string;
+  globalExitRoot: string;
+  mainnetExitRoot: string; // L1 root
+  rollupExitRoot: string; // L2 root
+  // ... other fields we might not need for this action
+}
+
+interface ZkEvmBatchRpcResponse {
+  result?: ZkEvmBatch;
+  error?: { message: string };
+}
+
+export const getExitRootsAction: Action = {
+  name: 'GET_EXIT_ROOTS',
+  similes: [
+    'GET_L1_L2_EXIT_ROOTS',
+    'FETCH_POLYGON_ZKEVM_EXIT_ROOTS',
+    'GET_POLYGON_ZKEVM_LATEST_EXIT_ROOTS',
+    'WHAT_ARE_THE_ZKEVM_EXIT_ROOTS',
+  ],
+  description:
+    'Fetches the current L1 (mainnet) and L2 (rollup) exit root hashes for Polygon zkEVM.',
+
+  validate: async (runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<boolean> => {
+    const alchemyApiKey = runtime.getSetting('ALCHEMY_API_KEY') || process.env.ALCHEMY_API_KEY;
+    const zkevmRpcUrl = runtime.getSetting('ZKEVM_RPC_URL') || process.env.ZKEVM_RPC_URL;
+
+    if (!alchemyApiKey && !zkevmRpcUrl) {
+      logger.warn('[getExitRootsAction] Neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured.');
+      return false;
+    }
+    // Since "no inputs required", basic config check is sufficient
+    // We can add more specific intent validation if needed later
+    logger.info('[getExitRootsAction] Validation passed: Sufficient configuration found.');
+    return true;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory, // Though not used for params, it's part of the signature
+    _state?: State,
+    _options?: { [key: string]: unknown },
+    callback?: HandlerCallback
+  ): Promise<Content> => {
+    logger.info('[getExitRootsAction] Handler called.');
+
+    const alchemyApiKey = runtime.getSetting('ALCHEMY_API_KEY') || process.env.ALCHEMY_API_KEY;
+    const zkevmRpcUrlSetting = runtime.getSetting('ZKEVM_RPC_URL') || process.env.ZKEVM_RPC_URL;
+
+    let l1Root: string | null = null;
+    let l2Root: string | null = null;
+    let methodUsed: string | null = null;
+    const errorMessages: string[] = [];
+
+    // 1. Attempt to use Alchemy API
+    if (alchemyApiKey) {
+      try {
+        logger.info('[getExitRootsAction] Attempting to use Alchemy API.');
+        // Polygon zkEVM Mainnet Alchemy URL
+        const alchemyUrl = `https://polygonzkevm-mainnet.g.alchemy.com/v2/${alchemyApiKey}`;
+        const requestBody = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'zkevm_getBatchByNumber',
+          params: ['latest', false], // Get the latest batch, no transaction details
+        };
+
+        const response = await fetch(alchemyUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `Alchemy API request failed with status ${response.status}: ${response.statusText}`
+          );
+        }
+
+        const data = (await response.json()) as ZkEvmBatchRpcResponse;
+
+        if (data.error) {
+          throw new Error(`Alchemy API returned error: ${data.error.message}`);
+        }
+
+        if (data.result && data.result.mainnetExitRoot && data.result.rollupExitRoot) {
+          if (
+            isValidHex32Bytes(data.result.mainnetExitRoot) &&
+            isValidHex32Bytes(data.result.rollupExitRoot)
+          ) {
+            l1Root = data.result.mainnetExitRoot;
+            l2Root = data.result.rollupExitRoot;
+            methodUsed = 'Alchemy API';
+            logger.info(`[getExitRootsAction] Roots from Alchemy: L1=${l1Root}, L2=${l2Root}`);
+          } else {
+            throw new Error('Alchemy API returned invalid root hash format.');
+          }
+        } else {
+          throw new Error('Alchemy API did not return the expected exit roots.');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`[getExitRootsAction] Error using Alchemy API: ${errorMessage}`);
+        errorMessages.push(`Alchemy API failed: ${errorMessage}`);
+        // Continue to fallback if Alchemy failed
+      }
+    }
+
+    // 2. Fallback to JSON-RPC if Alchemy failed or not configured
+    if ((!l1Root || !l2Root) && zkevmRpcUrlSetting) {
+      try {
+        logger.info('[getExitRootsAction] Attempting to use JSON-RPC fallback.');
+        const provider = new JsonRpcProvider(zkevmRpcUrlSetting);
+        const batch = (await provider.send('zkevm_getBatchByNumber', [
+          'latest',
+          false,
+        ])) as ZkEvmBatch | null; // Type assertion based on expected output
+
+        if (batch && batch.mainnetExitRoot && batch.rollupExitRoot) {
+          if (isValidHex32Bytes(batch.mainnetExitRoot) && isValidHex32Bytes(batch.rollupExitRoot)) {
+            l1Root = batch.mainnetExitRoot;
+            l2Root = batch.rollupExitRoot;
+            methodUsed = 'JSON-RPC';
+            logger.info(`[getExitRootsAction] Roots from JSON-RPC: L1=${l1Root}, L2=${l2Root}`);
+          } else {
+            throw new Error('JSON-RPC returned invalid root hash format.');
+          }
+        } else {
+          throw new Error('JSON-RPC did not return the expected exit roots or batch is null.');
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`[getExitRootsAction] Error using JSON-RPC: ${errorMessage}`);
+        errorMessages.push(`JSON-RPC failed: ${errorMessage}`);
+      }
+    }
+
+    // Handle result and errors
+    if (l1Root && l2Root && methodUsed) {
+      const responseText = `Polygon zkEVM Exit Roots (via ${methodUsed}):\nL1 (Mainnet) Root: ${l1Root}\nL2 (Rollup) Root: ${l2Root}`;
+      const responseContent: Content = {
+        text: responseText,
+        actions: ['GET_EXIT_ROOTS'],
+        data: {
+          l1Root,
+          l2Root,
+          source: methodUsed,
+          network: 'polygon-zkevm',
+          timestamp: Date.now(),
+        },
+      };
+
+      if (callback) {
+        await callback(responseContent);
+      }
+      return responseContent;
+    } else {
+      const comprehensiveErrorMessage = `Failed to retrieve Polygon zkEVM exit roots. Errors: ${errorMessages.join('; ')}`;
+      logger.error(`[getExitRootsAction] ${comprehensiveErrorMessage}`);
+      const errorContent: Content = {
+        text: comprehensiveErrorMessage,
+        actions: ['GET_EXIT_ROOTS'],
+        data: {
+          error: comprehensiveErrorMessage,
+          details: errorMessages,
+        },
+      };
+      if (callback) {
+        await callback(errorContent);
+      }
+      // As per Eliza's error handling, throwing an error here makes sense
+      // if the action's core purpose couldn't be fulfilled.
+      throw new Error(comprehensiveErrorMessage);
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: 'user1',
+        content: {
+          text: 'What are the current exit roots for Polygon zkEVM?',
+        },
+      },
+      {
+        name: 'assistant1',
+        // This is a placeholder; actual roots will vary.
+        content: {
+          text: 'Polygon zkEVM Exit Roots (via Alchemy API):\nL1 (Mainnet) Root: 0x0123...abc\nL2 (Rollup) Root: 0x4567...def',
+          actions: ['GET_EXIT_ROOTS'],
+          data: {
+            l1Root: '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            l2Root: '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567',
+            source: 'Alchemy API',
+            network: 'polygon-zkevm',
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: 'user2',
+        content: {
+          text: 'Fetch latest L1 and L2 exit roots on zkEVM.',
+        },
+      },
+      {
+        name: 'assistant2',
+        content: {
+          text: 'Polygon zkEVM Exit Roots (via JSON-RPC):\nL1 (Mainnet) Root: 0x...',
+          actions: ['GET_EXIT_ROOTS'],
+          data: {
+            l1Root: '0x...', // actual hash
+            l2Root: '0x...', // actual hash
+            source: 'JSON-RPC',
+          },
+        },
+      },
+    ],
+  ],
+};

--- a/packages/plugin-polygon-zkevm/src/actions/sendL2Transaction.ts
+++ b/packages/plugin-polygon-zkevm/src/actions/sendL2Transaction.ts
@@ -1,0 +1,356 @@
+import {
+  type Action,
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  type HandlerCallback,
+  type Content,
+  logger,
+  ModelType,
+  composePromptFromState,
+} from '@elizaos/core';
+import { z } from 'zod';
+import { JsonRpcProvider, Wallet, isAddress, parseEther, parseUnits } from 'ethers';
+import { extractParamsForSendL2TransactionTemplate } from '../templates';
+
+const POLYGON_ZKEVM_CHAIN_ID = 1101n;
+
+const extractedParamsSchema = z.object({
+  toAddress: z.string().refine(isAddress, { message: 'Invalid toAddress format.' }),
+  value: z
+    .string()
+    .regex(/^\d*\.?\d+$/, { message: 'Invalid value format, should be a number string.' }),
+  gasLimit: z
+    .string()
+    .regex(/^\d+$/, { message: 'Invalid gasLimit format, should be an integer string.' })
+    .optional(),
+  gasPrice: z
+    .string()
+    .regex(/^\d*\.?\d+$/, { message: 'Invalid gasPrice format, should be a number string (Gwei).' })
+    .optional(),
+  error: z.string().optional(),
+});
+
+type SendL2TransactionParams = z.infer<typeof extractedParamsSchema>;
+
+export const sendL2TransactionAction: Action = {
+  name: 'SEND_L2_TRANSACTION',
+  similes: [
+    'SEND_ZKEVM_ETH_TRANSFER',
+    'MAKE_L2_ETH_PAYMENT',
+    'TRANSFER_ETH_ON_POLYGON_ZKEVM',
+    'EXECUTE_NATIVE_TOKEN_TRANSFER_ZKEVM',
+  ],
+  description:
+    'Sends a native ETH (L2) transaction on Polygon zkEVM. Requires recipient address and value. Gas parameters are optional.',
+  validate: async (runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<boolean> => {
+    const privateKey = runtime.getSetting('PRIVATE_KEY') as string | undefined;
+    const alchemyApiKey = runtime.getSetting('ALCHEMY_API_KEY') as string | undefined;
+    const zkevmRpcUrl = runtime.getSetting('ZKEVM_RPC_URL') as string | undefined;
+
+    if (!privateKey) {
+      logger.warn('[sendL2TransactionAction] Validation failed: PRIVATE_KEY is not configured.');
+      return false;
+    }
+    if (!alchemyApiKey && !zkevmRpcUrl) {
+      logger.warn(
+        '[sendL2TransactionAction] Validation failed: Neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured.'
+      );
+      return false;
+    }
+    logger.info('[sendL2TransactionAction] Validation passed: Sufficient configuration found.');
+    return true;
+  },
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    state: State,
+    _options: any,
+    callback: HandlerCallback,
+    _responses: Memory[]
+  ): Promise<Content | void> => {
+    logger.info('[sendL2TransactionAction] Handler called.');
+
+    const alchemyApiKey = runtime.getSetting('ALCHEMY_API_KEY') as string | undefined;
+    const zkevmRpcUrl = runtime.getSetting('ZKEVM_RPC_URL') as string | undefined;
+    const privateKey = runtime.getSetting('PRIVATE_KEY') as string | undefined;
+
+    if (!privateKey) {
+      logger.error('[sendL2TransactionAction] Critical: PRIVATE_KEY is not configured.');
+      const errContent = {
+        text: 'Error: PRIVATE_KEY is not configured. Cannot send transaction.',
+        actions: [sendL2TransactionAction.name],
+      };
+      await callback(errContent);
+      return errContent;
+    }
+    if (!alchemyApiKey && !zkevmRpcUrl) {
+      logger.error('[sendL2TransactionAction] Critical: RPC endpoint not configured.');
+      const errContent = {
+        text: 'Error: RPC endpoint not configured. Cannot send transaction.',
+        actions: [sendL2TransactionAction.name],
+      };
+      await callback(errContent);
+      return errContent;
+    }
+
+    let extractedParams: SendL2TransactionParams | null = null;
+
+    try {
+      extractedParams = (await runtime.useModel(ModelType.OBJECT_LARGE, {
+        prompt: composePromptFromState({
+          state,
+          template: extractParamsForSendL2TransactionTemplate,
+        }),
+      })) as SendL2TransactionParams;
+
+      logger.debug('[sendL2TransactionAction] Parameters from LLM (useModel):', extractedParams);
+
+      const validationResult = extractedParamsSchema.safeParse(extractedParams);
+
+      if (!validationResult.success) {
+        const errorMsg = validationResult.error.errors.map((e) => e.message).join(', ');
+        throw new Error(`Invalid parameters from LLM: ${errorMsg}`);
+      }
+      if (validationResult.data.error) {
+        throw new Error(`LLM reported an error: ${validationResult.data.error}`);
+      }
+      extractedParams = validationResult.data;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(
+        `[sendL2TransactionAction] Failed to extract or validate parameters: ${errorMessage}`
+      );
+      const errorContent: Content = {
+        text: `Failed to process transaction request: ${errorMessage}`,
+        actions: [sendL2TransactionAction.name],
+        data: { error: errorMessage },
+      };
+      await callback(errorContent);
+      return errorContent;
+    }
+
+    if (!extractedParams) {
+      const errText = 'Parameter extraction unexpectedly failed.';
+      logger.error(`[sendL2TransactionAction] ${errText}`);
+      const errorContent: Content = { text: errText, actions: [sendL2TransactionAction.name] };
+      await callback(errorContent);
+      return errorContent;
+    }
+
+    const { toAddress, value, gasLimit: gasLimitStr, gasPrice: gasPriceStr } = extractedParams;
+
+    try {
+      const wallet = new Wallet(privateKey);
+      const fromAddress = wallet.address;
+      logger.info(`[sendL2TransactionAction] Wallet initialized for address: ${fromAddress}`);
+
+      const providers: { name: string; url: string; provider: JsonRpcProvider }[] = [];
+      if (alchemyApiKey) {
+        const url = `https://polygonzkevm-mainnet.g.alchemy.com/v2/${alchemyApiKey}`;
+        providers.push({
+          name: 'Alchemy',
+          url,
+          provider: new JsonRpcProvider(url, POLYGON_ZKEVM_CHAIN_ID),
+        });
+      }
+      if (zkevmRpcUrl) {
+        providers.push({
+          name: 'JSON-RPC',
+          url: zkevmRpcUrl,
+          provider: new JsonRpcProvider(zkevmRpcUrl, POLYGON_ZKEVM_CHAIN_ID),
+        });
+      }
+
+      if (providers.length === 0) {
+        const errText = 'Error: No RPC provider available in handler.';
+        logger.error(`[sendL2TransactionAction] ${errText}`);
+        const errorContent: Content = { text: errText, actions: [sendL2TransactionAction.name] };
+        await callback(errorContent);
+        return errorContent;
+      }
+
+      logger.info(
+        `[sendL2TransactionAction] Attempting to send ${value} ETH from ${fromAddress} to ${toAddress}`
+      );
+
+      let txHash: string | undefined;
+      let errorMessagesList: string[] = [];
+
+      for (const { name, provider, url } of providers) {
+        try {
+          logger.info(`[sendL2TransactionAction] Using provider: ${name} (${url})`);
+          const feeData = await provider.getFeeData();
+          const nonce = await provider.getTransactionCount(fromAddress, 'pending');
+          logger.debug(
+            `[sendL2TransactionAction] Nonce: ${nonce}, FeeData: ${JSON.stringify(feeData)}`
+          );
+
+          const parsedValue = parseEther(value);
+
+          const tx: any = {
+            to: toAddress,
+            value: parsedValue,
+            nonce: nonce,
+            chainId: POLYGON_ZKEVM_CHAIN_ID,
+            type: 0,
+          };
+
+          if (gasPriceStr) {
+            tx.gasPrice = parseUnits(gasPriceStr, 'gwei');
+          } else {
+            tx.gasPrice = feeData.gasPrice;
+            if (!tx.gasPrice && feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
+              tx.maxFeePerGas = feeData.maxFeePerGas;
+              tx.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
+              delete tx.gasPrice;
+            } else if (!tx.gasPrice) {
+              const defaultGasPrice = parseUnits('10', 'gwei');
+              logger.warn(
+                `[sendL2TransactionAction] Could not determine gas price from feeData, attempting to use default: ${defaultGasPrice.toString()} Gwei`
+              );
+              tx.gasPrice = defaultGasPrice;
+            }
+          }
+
+          if (gasLimitStr) {
+            tx.gasLimit = BigInt(gasLimitStr);
+          } else {
+            const tempTxForEstimate = {
+              from: fromAddress,
+              to: toAddress,
+              value: parsedValue,
+            };
+            tx.gasLimit = await provider.estimateGas(tempTxForEstimate);
+          }
+          // Custom stringify for logging to avoid BigInt errors
+          const txForLogging = { ...tx };
+          for (const key in txForLogging) {
+            if (typeof txForLogging[key] === 'bigint') {
+              txForLogging[key] = txForLogging[key].toString() + 'n'; // Indicate it was a BigInt
+            }
+          }
+          logger.debug(
+            `[sendL2TransactionAction] Transaction object prepared: ${JSON.stringify(txForLogging)}`
+          );
+
+          const signedTx = await wallet.signTransaction(tx);
+          logger.info('[sendL2TransactionAction] Transaction signed.');
+
+          const broadcastResponse = await provider.broadcastTransaction(signedTx);
+          txHash = broadcastResponse.hash;
+          logger.info(
+            `[sendL2TransactionAction] Transaction broadcasted via ${name}. Hash: ${txHash}`
+          );
+          break;
+        } catch (error) {
+          const e = error as Error;
+          logger.error(`[sendL2TransactionAction] Error with provider ${name}: ${e.message}`, e);
+          errorMessagesList.push(`Failed with ${name}: ${e.message}`);
+        }
+      }
+
+      if (txHash) {
+        const responseText = `Transaction sent successfully!\nHash: ${txHash}\nRecipient: ${toAddress}\nAmount: ${value} ETH`;
+        const responseContent: Content = {
+          text: responseText,
+          actions: [sendL2TransactionAction.name, 'GET_TRANSACTION_RECEIPT'],
+          data: {
+            transactionHash: txHash,
+            toAddress,
+            value,
+            fromAddress,
+            chain: 'polygon-zkevm',
+            timestamp: Date.now(),
+          },
+          source: _message.content.source,
+        };
+        await callback(responseContent);
+        return responseContent;
+      } else {
+        const combinedError = `Failed to send transaction after trying all providers. Errors: ${errorMessagesList.join('; ')}`;
+        logger.error(`[sendL2TransactionAction] ${combinedError}`);
+        const errorContent: Content = {
+          text: `Error: ${combinedError}`,
+          source: _message.content.source,
+          actions: [sendL2TransactionAction.name],
+        };
+        await callback(errorContent);
+        return errorContent;
+      }
+    } catch (error) {
+      const e = error as Error;
+      logger.error(`[sendL2TransactionAction] Critical unhandled error: ${e.message}`, e);
+      const errorContent: Content = {
+        text: `Critical error processing transaction: ${e.message}`,
+        source: _message.content.source,
+        actions: [sendL2TransactionAction.name],
+      };
+      await callback(errorContent);
+      return errorContent;
+    }
+  },
+  examples: [
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'Send 0.5 ETH to 0xRecipientAddress123...',
+        },
+      },
+      {
+        name: '{{name2}}',
+        content: {
+          text: 'Transaction sent successfully!\nHash: 0xTxHash123...\nRecipient: 0xRecipientAddress123...\nAmount: 0.5 ETH',
+          actions: ['SEND_L2_TRANSACTION', 'GET_TRANSACTION_RECEIPT'],
+          data: {
+            transactionHash: '0xTxHash123...',
+            toAddress: '0xRecipientAddress123...',
+            value: '0.5',
+            fromAddress: '0xSenderAddress...',
+            chain: 'polygon-zkevm',
+            timestamp: 1678886400000,
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'Transfer 1.2 ETH to 0xAnotherAddress456... with gas limit 30000 and gas price 10 Gwei',
+        },
+      },
+      {
+        name: '{{name2}}',
+        content: {
+          text: 'Transaction sent successfully!\nHash: 0xAnotherTxHash456...\nRecipient: 0xAnotherAddress456...\nAmount: 1.2 ETH',
+          actions: ['SEND_L2_TRANSACTION', 'GET_TRANSACTION_RECEIPT'],
+          data: {
+            transactionHash: '0xAnotherTxHash456...',
+            toAddress: '0xAnotherAddress456...',
+            value: '1.2',
+            fromAddress: '0xSenderAddress...',
+            chain: 'polygon-zkevm',
+            timestamp: 1678886400000,
+          },
+        },
+      },
+    ],
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'I want to send some eth to my friend',
+        },
+      },
+      {
+        name: '{{name2}}',
+        content: {
+          text: "LLM reported an error: Missing or invalid required parameters: 'toAddress' and 'value' must be provided and valid.",
+          actions: ['SEND_L2_TRANSACTION'],
+        },
+      },
+    ],
+  ],
+};

--- a/packages/plugin-polygon-zkevm/src/plugin.ts
+++ b/packages/plugin-polygon-zkevm/src/plugin.ts
@@ -29,6 +29,9 @@ import { getAccountBalanceAction } from './actions/getAccountBalance';
 import { getGasPriceEstimatesAction } from './actions/getGasPriceEstimates';
 import { checkBlockStatusAction } from './actions/checkBlockStatus';
 import { getBatchInfoAction } from './actions/getBatchInfo';
+import { getExitRootsAction } from './actions/getExitRoots';
+import { estimateZkNonceAction } from './actions/estimateZkNonce';
+import { sendL2TransactionAction } from './actions/sendL2Transaction';
 
 /**
  * Define the configuration schema for the plugin with the following properties:
@@ -261,6 +264,9 @@ const plugin: Plugin = {
     getGasPriceEstimatesAction,
     checkBlockStatusAction,
     getBatchInfoAction,
+    getExitRootsAction,
+    estimateZkNonceAction,
+    sendL2TransactionAction,
   ],
   providers: [helloWorldProvider],
 };

--- a/packages/plugin-polygon-zkevm/src/templates.ts
+++ b/packages/plugin-polygon-zkevm/src/templates.ts
@@ -49,3 +49,86 @@ If no valid block hash is found, or if the user's intent is unclear, you MUST re
 }
 \`\`\`
 `;
+
+export const extractAddressForZkNonceTemplate = `You are an AI assistant. Your task is to extract the Ethereum address from the user's message for estimating the zkNonce/zkCounter.
+The address must be a valid 42-character hexadecimal string starting with '0x'.
+
+Review the recent messages:
+<recent_messages>
+{{recentMessages}}
+</recent_messages>
+
+Based on the conversation, identify the Ethereum address for which the zkNonce is requested.
+
+Respond with a JSON markdown block containing only the extracted address.
+The JSON should have this structure:
+\`\`\`json
+{
+    "address": "0x..."
+}
+\`\`\`
+
+If no valid Ethereum address is found specifically for a zkNonce/zkCounter request, or if the user's intent is unclear, you MUST respond with the following JSON structure:
+\`\`\`json
+{
+    "error": "Ethereum address not found or invalid. Please specify a valid 42-character hexadecimal address starting with '0x' for zkNonce estimation."
+}
+\`\`\`
+`;
+
+export const extractParamsForSendL2TransactionTemplate = `You are an AI assistant. Your task is to extract parameters from the user's message to send a native ETH transaction on Polygon zkEVM.
+
+The user must specify the recipient address ('toAddress') and the amount of ETH to send ('value').
+Optionally, the user can specify 'gasLimit' and 'gasPrice'.
+
+- 'toAddress' must be a valid 42-character Ethereum hexadecimal address starting with '0x'.
+- 'value' should be a string representing the amount of ETH, e.g., "0.1", "1.5".
+- 'gasLimit' (optional) should be a string representing a number, e.g., "21000".
+- 'gasPrice' (optional) should be a string representing the price in Gwei, e.g., "5", "10.5".
+
+Review the recent messages:
+<recent_messages>
+{{recentMessages}}
+</recent_messages>
+
+Based on the conversation, identify the parameters for the transaction.
+
+Respond with a JSON markdown block containing the extracted parameters.
+The JSON should have this structure:
+\`\`\`json
+{
+    "toAddress": "0x...",
+    "value": "0.1", // ETH
+    "gasLimit": "21000", // Optional
+    "gasPrice": "5" // Optional, in Gwei
+}
+\`\`\`
+
+If 'toAddress' or 'value' cannot be clearly identified, or if 'toAddress' is invalid, you MUST respond with the following JSON structure:
+\`\`\`json
+{
+    "error": "Missing or invalid required parameters: 'toAddress' and 'value' must be provided and valid."
+}
+\`\`\`
+
+If optional parameters are provided but seem malformed (e.g., non-numeric gasLimit), you can omit them or return an error if critical. For this task, try to extract what's valid and omit invalid optional ones.
+The 'from' address is handled by the system using a preconfigured private key. Do not ask for or try to extract a 'from' address.
+Example: User says "Send 0.05 ETH to 0x123abc..."
+Response:
+\`\`\`json
+{
+    "toAddress": "0x123abc...",
+    "value": "0.05"
+}
+\`\`\`
+Example: User says "Transfer 1 ETH to 0xdef456... with gas limit 25000 and gas price 10 Gwei"
+Response:
+\`\`\`json
+{
+    "toAddress": "0xdef456...",
+    "value": "1",
+    "gasLimit": "25000",
+    "gasPrice": "10"
+}
+\`\`\`
+`;

--- a/packages/plugin-polygon-zkevm/tests/unit/estimateZkNonce.test.ts
+++ b/packages/plugin-polygon-zkevm/tests/unit/estimateZkNonce.test.ts
@@ -1,0 +1,244 @@
+import { estimateZkNonceAction } from '../../src/actions/estimateZkNonce';
+import {
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  type Content,
+  logger,
+  ModelType,
+  composePromptFromState,
+} from '@elizaos/core';
+import { extractAddressForZkNonceTemplate } from '../../src/templates';
+
+// Mock the logger
+jest.mock('@elizaos/core', () => ({
+  ...jest.requireActual('@elizaos/core'),
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  composePromptFromState: jest.fn(), // Mock this as well
+}));
+
+// Mock 'ethers' JsonRpcProvider
+const mockSend = jest.fn();
+jest.mock('ethers', () => ({
+  ...jest.requireActual('ethers'),
+  JsonRpcProvider: jest.fn().mockImplementation(() => ({
+    send: mockSend,
+  })),
+  isAddress: jest.fn((addr) => /^0x[a-fA-F0-9]{40}$/.test(addr)), // Simple mock for isAddress
+}));
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+const mockRuntime = {
+  getSetting: jest.fn(),
+  useModel: jest.fn(),
+} as unknown as IAgentRuntime;
+
+const mockMemory = {
+  content: { source: 'test-source' },
+} as Memory;
+const mockState = {} as State;
+const mockCallback = jest.fn() as jest.MockedFunction<(content: Content) => Promise<void>>;
+
+const testAddress = '0x1234567890123456789012345678901234567890';
+const testNonceHex = '0xa'; // 10 in decimal
+const testNonceDecimal = '10';
+
+describe('estimateZkNonceAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fetch as jest.Mock).mockClear();
+    mockSend.mockClear();
+    mockCallback.mockClear();
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return 'test-alchemy-key';
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      return undefined;
+    });
+    (mockRuntime.useModel as jest.Mock).mockResolvedValue({ address: testAddress });
+    (composePromptFromState as jest.Mock).mockReturnValue('mocked-prompt');
+  });
+
+  describe('handler', () => {
+    it('should return nonce using Alchemy if API key is provided', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: testNonceHex }),
+      });
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(mockRuntime.useModel).toHaveBeenCalledWith(ModelType.OBJECT_LARGE, {
+        prompt: 'mocked-prompt',
+      });
+      expect(composePromptFromState).toHaveBeenCalledWith({
+        state: mockState,
+        template: extractAddressForZkNonceTemplate,
+      });
+      expect(fetch).toHaveBeenCalledWith(
+        'https://polygonzkevm-mainnet.g.alchemy.com/v2/test-alchemy-key',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'eth_getTransactionCount',
+            params: [testAddress, 'pending'],
+          }),
+        })
+      );
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: `The next zk-nonce (zkCounter) for address ${testAddress} is: ${testNonceDecimal}`,
+          data: {
+            address: testAddress,
+            zkNonce: testNonceDecimal,
+          },
+        })
+      );
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to ZKEVM_RPC_URL if Alchemy API key is not provided', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ALCHEMY_API_KEY') return undefined;
+        if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+        return undefined;
+      });
+      mockSend.mockResolvedValueOnce(testNonceHex);
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(mockSend).toHaveBeenCalledWith('eth_getTransactionCount', [testAddress, 'pending']);
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: `The next zk-nonce (zkCounter) for address ${testAddress} is: ${testNonceDecimal}`,
+        })
+      );
+    });
+
+    it('should fallback to ZKEVM_RPC_URL if Alchemy fetch fails', async () => {
+      (fetch as jest.Mock).mockRejectedValueOnce(new Error('Alchemy down'));
+      mockSend.mockResolvedValueOnce(testNonceHex);
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: `The next zk-nonce (zkCounter) for address ${testAddress} is: ${testNonceDecimal}`,
+        })
+      );
+    });
+
+    it('should return error if address extraction fails', async () => {
+      (mockRuntime.useModel as jest.Mock).mockResolvedValueOnce({
+        error: 'Failed to extract address',
+      });
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'Failed to process zkNonce request: LLM reported an error: Failed to extract address',
+        })
+      );
+    });
+
+    it('should return error if extracted address is invalid', async () => {
+      (mockRuntime.useModel as jest.Mock).mockResolvedValueOnce({ address: 'invalid-address' });
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'Failed to process zkNonce request: Invalid parameters from LLM: Invalid address format.',
+        })
+      );
+    });
+
+    it('should return error if RPC call fails after Alchemy fails', async () => {
+      (fetch as jest.Mock).mockRejectedValueOnce(new Error('Alchemy down'));
+      mockSend.mockRejectedValueOnce(new Error('RPC down'));
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'Error: Failed to fetch nonce after trying all providers. Errors: Failed with Alchemy: Alchemy down; Failed with JSON-RPC: RPC down',
+        })
+      );
+    });
+
+    it('should handle error if only Alchemy configured and it fails', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ALCHEMY_API_KEY') return 'test-alchemy-key';
+        if (key === 'ZKEVM_RPC_URL') return undefined;
+        return undefined;
+      });
+      (fetch as jest.Mock).mockRejectedValueOnce(new Error('Alchemy error'));
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'Error: Failed to fetch nonce after trying all providers. Errors: Failed with Alchemy: Alchemy error',
+        })
+      );
+    });
+
+    it('should handle error if only RPC configured and it fails', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ALCHEMY_API_KEY') return undefined;
+        if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+        return undefined;
+      });
+      mockSend.mockRejectedValueOnce(new Error('RPC error'));
+
+      await estimateZkNonceAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'Error: Failed to fetch nonce after trying all providers. Errors: Failed with JSON-RPC: RPC error',
+        })
+      );
+    });
+  });
+
+  describe('validate', () => {
+    it('should return true if ALCHEMY_API_KEY is configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ALCHEMY_API_KEY') return 'test-key';
+        return undefined;
+      });
+      const isValid = await estimateZkNonceAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(true);
+    });
+
+    it('should return true if ZKEVM_RPC_URL is configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ZKEVM_RPC_URL') return 'http://test-url.com';
+        return undefined;
+      });
+      const isValid = await estimateZkNonceAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(true);
+    });
+
+    it('should return false if neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockReturnValue(undefined);
+      const isValid = await estimateZkNonceAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[estimateZkNonceAction] Validation failed: Neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured.'
+      );
+    });
+  });
+});

--- a/packages/plugin-polygon-zkevm/tests/unit/getExitRoots.test.ts
+++ b/packages/plugin-polygon-zkevm/tests/unit/getExitRoots.test.ts
@@ -1,0 +1,308 @@
+import { getExitRootsAction } from '../../src/actions/getExitRoots';
+import { type IAgentRuntime, type Memory, type State, type Content, logger } from '@elizaos/core';
+
+// Mock the logger to prevent console output during tests
+jest.mock('@elizaos/core', () => ({
+  ...jest.requireActual('@elizaos/core'),
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock 'ethers' JsonRpcProvider
+const mockSend = jest.fn();
+jest.mock('ethers', () => ({
+  ...jest.requireActual('ethers'),
+  JsonRpcProvider: jest.fn().mockImplementation(() => ({
+    send: mockSend,
+  })),
+}));
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+const mockRuntime = {
+  getSetting: jest.fn(),
+  useModel: jest.fn(),
+  getService: jest.fn(),
+  getServices: jest.fn(),
+  getPlugin: jest.fn(),
+  getPlugins: jest.fn(),
+  getProvider: jest.fn(),
+  getProviders: jest.fn(),
+} as unknown as IAgentRuntime;
+
+const mockMemory = {} as Memory;
+const mockState = {} as State;
+const mockCallback = jest.fn() as jest.MockedFunction<(content: Content) => Promise<void>>;
+
+const validL1Root = '0x' + '1'.repeat(64);
+const validL2Root = '0x' + '2'.repeat(64);
+
+describe('getExitRootsAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks(); // Clear all mocks before each test
+    (fetch as jest.Mock).mockClear();
+    mockSend.mockClear();
+    mockCallback.mockClear();
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return 'test-alchemy-key';
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      return undefined;
+    });
+  });
+
+  it('should return L1 and L2 roots using Alchemy if API key is provided', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: {
+          mainnetExitRoot: validL1Root,
+          rollupExitRoot: validL2Root,
+        },
+      }),
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://polygonzkevm-mainnet.g.alchemy.com/v2/test-alchemy-key',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'zkevm_getBatchByNumber',
+          params: ['latest', false],
+        }),
+      })
+    );
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: `Current Exit Roots:\nL1 Root (Mainnet): ${validL1Root}\nL2 Root (Rollup): ${validL2Root}`,
+        data: {
+          l1Root: validL1Root,
+          l2Root: validL2Root,
+        },
+      })
+    );
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('should fallback to ZKEVM_RPC_URL if Alchemy API key is not provided', async () => {
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return undefined;
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      return undefined;
+    });
+    mockSend.mockResolvedValueOnce({
+      mainnetExitRoot: validL1Root,
+      rollupExitRoot: validL2Root,
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockSend).toHaveBeenCalledWith('zkevm_getBatchByNumber', ['latest', false]);
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: `Current Exit Roots:\nL1 Root (Mainnet): ${validL1Root}\nL2 Root (Rollup): ${validL2Root}`,
+        data: {
+          l1Root: validL1Root,
+          l2Root: validL2Root,
+        },
+      })
+    );
+  });
+
+  it('should fallback to ZKEVM_RPC_URL if Alchemy fetch fails', async () => {
+    (fetch as jest.Mock).mockRejectedValueOnce(new Error('Alchemy down'));
+    mockSend.mockResolvedValueOnce({
+      mainnetExitRoot: validL1Root,
+      rollupExitRoot: validL2Root,
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledWith('zkevm_getBatchByNumber', ['latest', false]);
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: `Current Exit Roots:\nL1 Root (Mainnet): ${validL1Root}\nL2 Root (Rollup): ${validL2Root}`,
+        data: {
+          l1Root: validL1Root,
+          l2Root: validL2Root,
+        },
+      })
+    );
+  });
+
+  it('should return an error if neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured', async () => {
+    (mockRuntime.getSetting as jest.Mock).mockReturnValue(undefined);
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Error: Neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured.',
+      })
+    );
+  });
+
+  it('should return an error if Alchemy response is not ok', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Gateway Timeout',
+    });
+    mockSend.mockResolvedValueOnce({
+      // Provide a valid fallback
+      mainnetExitRoot: validL1Root,
+      rollupExitRoot: validL2Root,
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+    // It should try Alchemy, fail, then try RPC
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: `Current Exit Roots:\nL1 Root (Mainnet): ${validL1Root}\nL2 Root (Rollup): ${validL2Root}`,
+      })
+    );
+  });
+
+  it('should return an error if Alchemy response structure is invalid', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: {} }), // Missing roots
+    });
+    mockSend.mockResolvedValueOnce({
+      // Provide a valid fallback
+      mainnetExitRoot: validL1Root,
+      rollupExitRoot: validL2Root,
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+    // It should try Alchemy, fail due to structure, then try RPC
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: `Current Exit Roots:\nL1 Root (Mainnet): ${validL1Root}\nL2 Root (Rollup): ${validL2Root}`,
+      })
+    );
+  });
+
+  it('should return an error if RPC call fails', async () => {
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return undefined; // Force RPC
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      return undefined;
+    });
+    mockSend.mockRejectedValueOnce(new Error('RPC down'));
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Error: Failed to fetch exit roots after trying all providers. Errors: Failed with JSON-RPC: RPC down',
+      })
+    );
+  });
+
+  it('should return an error if L1 root from Alchemy is invalid', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: {
+          mainnetExitRoot: 'invalid-root',
+          rollupExitRoot: validL2Root,
+        },
+      }),
+    });
+    // Fallback should be called
+    mockSend.mockResolvedValueOnce({
+      mainnetExitRoot: validL1Root,
+      rollupExitRoot: validL2Root,
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid L1 root from Alchemy')
+    );
+    expect(mockSend).toHaveBeenCalledTimes(1); // Fallback was attempted
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          l1Root: validL1Root, // from fallback
+          l2Root: validL2Root,
+        },
+      })
+    );
+  });
+
+  it('should return an error if L2 root from RPC is invalid', async () => {
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return undefined; // Force RPC
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      return undefined;
+    });
+    mockSend.mockResolvedValueOnce({
+      mainnetExitRoot: validL1Root,
+      rollupExitRoot: 'invalid-root',
+    });
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid L2 root from JSON-RPC')
+    );
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Error: Failed to fetch exit roots after trying all providers. Errors: Failed with JSON-RPC: Invalid L2 root format from JSON-RPC: invalid-root',
+      })
+    );
+  });
+
+  it('should handle case where only ALCHEMY_API_KEY is provided and it fails, with no ZKEVM_RPC_URL fallback', async () => {
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return 'test-alchemy-key';
+      if (key === 'ZKEVM_RPC_URL') return undefined; // No fallback RPC
+      return undefined;
+    });
+    (fetch as jest.Mock).mockRejectedValueOnce(new Error('Alchemy fetch failed'));
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Error: Failed to fetch exit roots after trying all providers. Errors: Failed with Alchemy: Alchemy fetch failed',
+      })
+    );
+  });
+
+  it('should handle case where only ZKEVM_RPC_URL is provided and it fails, with no ALCHEMY_API_KEY', async () => {
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return undefined; // No Alchemy
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      return undefined;
+    });
+    mockSend.mockRejectedValueOnce(new Error('RPC call failed'));
+
+    await getExitRootsAction.handler(mockRuntime, mockMemory, mockState, {}, mockCallback, []);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Error: Failed to fetch exit roots after trying all providers. Errors: Failed with JSON-RPC: RPC call failed',
+      })
+    );
+  });
+});

--- a/packages/plugin-polygon-zkevm/tests/unit/sendL2Transaction.test.ts
+++ b/packages/plugin-polygon-zkevm/tests/unit/sendL2Transaction.test.ts
@@ -1,0 +1,406 @@
+import { sendL2TransactionAction } from '../../src/actions/sendL2Transaction';
+import {
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  type Content,
+  logger,
+  ModelType,
+  composePromptFromState,
+} from '@elizaos/core';
+import { extractParamsForSendL2TransactionTemplate } from '../../src/templates';
+import { JsonRpcProvider, Wallet, parseEther, parseUnits, FeeData } from 'ethers';
+
+// Mock core and logger
+jest.mock('@elizaos/core', () => ({
+  ...jest.requireActual('@elizaos/core'),
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  composePromptFromState: jest.fn(),
+}));
+
+// Mock ethers
+const mockGetTransactionCount = jest.fn();
+const mockGetFeeData = jest.fn();
+const mockEstimateGas = jest.fn();
+const mockSignTransaction = jest.fn();
+const mockBroadcastTransaction = jest.fn();
+const mockSend = jest.fn(); // For generic RPC provider
+
+jest.mock('ethers', () => ({
+  ...jest.requireActual('ethers'),
+  JsonRpcProvider: jest.fn().mockImplementation(() => ({
+    getTransactionCount: mockGetTransactionCount,
+    getFeeData: mockGetFeeData,
+    estimateGas: mockEstimateGas,
+    broadcastTransaction: mockBroadcastTransaction,
+    send: mockSend, // for direct calls if any, or for the generic provider instance
+  })),
+  Wallet: jest.fn().mockImplementation((privateKey) => ({
+    address: '0xMockFromAddress',
+    privateKey,
+    signTransaction: mockSignTransaction,
+    // Mock connect if you create a new Wallet instance with a provider
+    connect: jest.fn().mockReturnThis(),
+  })),
+  isAddress: jest.fn((addr) => /^0x[a-fA-F0-9]{40}$/.test(addr)),
+  parseEther: jest.fn((val) => BigInt(parseFloat(val) * 1e18)),
+  parseUnits: jest.fn((val, unit) => {
+    if (unit === 'gwei') return BigInt(parseFloat(val) * 1e9);
+    return BigInt(val);
+  }),
+}));
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+const mockRuntime = {
+  getSetting: jest.fn(),
+  useModel: jest.fn(),
+} as unknown as IAgentRuntime;
+
+const mockMemory = {
+  content: { source: 'test-source' },
+} as Memory;
+const mockState = {} as State;
+const mockCallback = jest.fn() as jest.MockedFunction<(content: Content) => Promise<void>>;
+
+const testToAddress = '0x1234567890123456789012345678901234567890';
+const testValue = '0.1';
+const testPrivateKey = '0x' + 'a'.repeat(64);
+const testTxHash = '0x' + 't'.repeat(64);
+
+describe('sendL2TransactionAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fetch as jest.Mock).mockClear();
+    mockSend.mockClear();
+    mockCallback.mockClear();
+    (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ALCHEMY_API_KEY') return 'test-alchemy-key';
+      if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+      if (key === 'PRIVATE_KEY') return testPrivateKey;
+      return undefined;
+    });
+    (composePromptFromState as jest.Mock).mockReturnValue('mocked-prompt-sendtx');
+    (mockRuntime.useModel as jest.Mock).mockResolvedValue({
+      toAddress: testToAddress,
+      value: testValue,
+    });
+
+    // Reset ethers mocks specific to provider calls
+    mockGetTransactionCount.mockResolvedValue(10); // Default nonce
+    mockGetFeeData.mockResolvedValue(
+      new FeeData(BigInt(10e9)) // 10 Gwei gasPrice
+    );
+    mockEstimateGas.mockResolvedValue(BigInt(21000)); // Default gas limit
+    mockSignTransaction.mockResolvedValue('signed-tx-payload');
+    mockBroadcastTransaction.mockResolvedValue({ hash: testTxHash });
+    mockSend.mockResolvedValue({ hash: testTxHash }); // For generic provider broadcasting
+
+    // Mock Alchemy fetch behavior
+    (fetch as jest.Mock).mockImplementation(async (url, options) => {
+      if (typeof options?.body !== 'string') throw new Error('Fetch body not stringified');
+      const body = JSON.parse(options.body);
+      if (body.method === 'eth_getTransactionCount') {
+        return { ok: true, json: async () => ({ result: '0xa' }) }; // 10
+      }
+      if (body.method === 'eth_feeData' || body.method === 'eth_gasPrice') {
+        // Alchemy might use eth_gasPrice or internal fee data logic
+        return { ok: true, json: async () => ({ result: { gasPrice: '0x2540be400' } }) }; // 10 Gwei
+      }
+      if (body.method === 'eth_estimateGas') {
+        return { ok: true, json: async () => ({ result: '0x5208' }) }; // 21000
+      }
+      if (body.method === 'eth_sendRawTransaction') {
+        return { ok: true, json: async () => ({ result: testTxHash }) };
+      }
+      return { ok: false, statusText: 'Unhandled mock fetch' };
+    });
+  });
+
+  describe('handler', () => {
+    it('should send transaction via Alchemy with extracted params', async () => {
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+
+      expect(mockRuntime.useModel).toHaveBeenCalledWith(ModelType.OBJECT_LARGE, {
+        prompt: 'mocked-prompt-sendtx',
+      });
+      expect(Wallet).toHaveBeenCalledWith(testPrivateKey);
+      // Verify provider interactions (assuming Alchemy is the first provider)
+      expect(mockGetTransactionCount).toHaveBeenCalledWith('0xMockFromAddress', 'pending');
+      expect(mockGetFeeData).toHaveBeenCalled();
+      expect(mockEstimateGas).toHaveBeenCalled();
+      expect(mockSignTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: testToAddress,
+          value: parseEther(testValue),
+          nonce: 10,
+          type: 0,
+          gasLimit: BigInt(21000),
+          gasPrice: BigInt(10e9),
+        })
+      );
+      expect(mockBroadcastTransaction).toHaveBeenCalledWith('signed-tx-payload');
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining(`Transaction sent successfully!\nHash: ${testTxHash}`),
+          data: expect.objectContaining({ transactionHash: testTxHash }),
+        })
+      );
+    });
+
+    it('should use user-provided gasLimit and gasPrice via Alchemy', async () => {
+      const userGasLimit = '30000';
+      const userGasPrice = '15'; // Gwei
+      (mockRuntime.useModel as jest.Mock).mockResolvedValue({
+        toAddress: testToAddress,
+        value: testValue,
+        gasLimit: userGasLimit,
+        gasPrice: userGasPrice,
+      });
+      mockEstimateGas.mockClear(); // Should not be called
+
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+
+      expect(mockEstimateGas).not.toHaveBeenCalled();
+      expect(mockSignTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasLimit: BigInt(userGasLimit),
+          gasPrice: parseUnits(userGasPrice, 'gwei'),
+        })
+      );
+      expect(mockBroadcastTransaction).toHaveBeenCalled();
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining(testTxHash) })
+      );
+    });
+
+    it('should fallback to JSON-RPC if Alchemy is not configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ALCHEMY_API_KEY') return undefined;
+        if (key === 'ZKEVM_RPC_URL') return 'http://test-rpc-url.com';
+        if (key === 'PRIVATE_KEY') return testPrivateKey;
+        return undefined;
+      });
+      // Reset specific JsonRpcProvider mocks for this test
+      mockGetTransactionCount.mockResolvedValueOnce(12);
+      mockGetFeeData.mockResolvedValueOnce(new FeeData(BigInt(12e9)));
+      mockEstimateGas.mockResolvedValueOnce(BigInt(22000));
+      mockBroadcastTransaction.mockResolvedValueOnce({ hash: '0xrpcHash' });
+
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+
+      expect(JsonRpcProvider).toHaveBeenCalledWith('http://test-rpc-url.com', 1101n);
+      expect(mockGetTransactionCount).toHaveBeenCalledWith('0xMockFromAddress', 'pending');
+      expect(mockGetFeeData).toHaveBeenCalled();
+      expect(mockEstimateGas).toHaveBeenCalled();
+      expect(mockSignTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ nonce: 12, gasPrice: BigInt(12e9) })
+      );
+      expect(mockBroadcastTransaction).toHaveBeenCalledWith('signed-tx-payload');
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining('0xrpcHash') })
+      );
+    });
+
+    it('should fallback to JSON-RPC if Alchemy call fails', async () => {
+      // First provider (Alchemy) will use its JsonRpcProvider instance which has mocks set up.
+      // Let's make broadcastTransaction fail for the first provider (Alchemy)
+      mockBroadcastTransaction.mockRejectedValueOnce(new Error('Alchemy broadcast error'));
+      // Setup the second provider (RPC) to succeed
+      const rpcProviderInstance = {
+        getTransactionCount: jest.fn().mockResolvedValue(15),
+        getFeeData: jest.fn().mockResolvedValue(new FeeData(BigInt(15e9))),
+        estimateGas: jest.fn().mockResolvedValue(BigInt(25000)),
+        broadcastTransaction: jest.fn().mockResolvedValue({ hash: '0xrpcFallbackHash' }),
+      };
+      const originalJsonRpcProvider = jest.requireActual('ethers').JsonRpcProvider;
+      (JsonRpcProvider as jest.Mock)
+        .mockImplementationOnce(() => ({
+          // For Alchemy (will fail broadcast)
+          getTransactionCount: mockGetTransactionCount,
+          getFeeData: mockGetFeeData,
+          estimateGas: mockEstimateGas,
+          broadcastTransaction: mockBroadcastTransaction, // This is the one that fails
+        }))
+        .mockImplementationOnce(() => rpcProviderInstance); // For generic RPC (will succeed)
+
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error with provider Alchemy'),
+        expect.any(Error)
+      );
+      expect(rpcProviderInstance.broadcastTransaction).toHaveBeenCalledWith('signed-tx-payload');
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining('0xrpcFallbackHash') })
+      );
+    });
+
+    it('should return error if LLM parameter extraction fails (e.g. missing toAddress)', async () => {
+      (mockRuntime.useModel as jest.Mock).mockResolvedValue({
+        value: testValue /* missing toAddress */,
+      });
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('Invalid parameters from LLM: Invalid toAddress format.'),
+        })
+      );
+    });
+
+    it('should return error if LLM reports an error', async () => {
+      const llmError = 'LLM could not determine parameters.';
+      (mockRuntime.useModel as jest.Mock).mockResolvedValue({ error: llmError });
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: `Failed to process transaction request: LLM reported an error: ${llmError}`,
+        })
+      );
+    });
+
+    it('should return error if all providers fail', async () => {
+      mockBroadcastTransaction.mockRejectedValue(new Error('Provider error')); // Both Alchemy and RPC will use this mock and fail
+      (JsonRpcProvider as jest.Mock).mockImplementation(() => ({
+        getTransactionCount: mockGetTransactionCount,
+        getFeeData: mockGetFeeData,
+        estimateGas: mockEstimateGas,
+        broadcastTransaction: mockBroadcastTransaction, // This will be rejected for both
+      }));
+
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+      expect(mockCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining(
+            'Failed to send transaction after trying all providers. Errors: Failed with Alchemy: Provider error; Failed with JSON-RPC: Provider error'
+          ),
+        })
+      );
+    });
+
+    it('should use default gas price if feeData.gasPrice is null and EIP-1559 fields are also null', async () => {
+      mockGetFeeData.mockResolvedValue(new FeeData(null, null, null)); // All null
+      await sendL2TransactionAction.handler(
+        mockRuntime,
+        mockMemory,
+        mockState,
+        {},
+        mockCallback,
+        []
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Could not determine gas price from feeData, attempting to use default:'
+        )
+      );
+      expect(mockSignTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasPrice: parseUnits('10', 'gwei'), // Default 10 Gwei
+        })
+      );
+    });
+  });
+
+  describe('validate', () => {
+    it('should return false if PRIVATE_KEY is not configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'PRIVATE_KEY') return undefined;
+        return 'something'; // Other keys are present
+      });
+      const isValid = await sendL2TransactionAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('PRIVATE_KEY is not configured')
+      );
+    });
+
+    it('should return false if neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'PRIVATE_KEY') return testPrivateKey;
+        if (key === 'ALCHEMY_API_KEY') return undefined;
+        if (key === 'ZKEVM_RPC_URL') return undefined;
+        return undefined;
+      });
+      const isValid = await sendL2TransactionAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Neither ALCHEMY_API_KEY nor ZKEVM_RPC_URL is configured')
+      );
+    });
+
+    it('should return true if PRIVATE_KEY and ALCHEMY_API_KEY are configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'PRIVATE_KEY') return testPrivateKey;
+        if (key === 'ALCHEMY_API_KEY') return 'test-key';
+        return undefined;
+      });
+      const isValid = await sendL2TransactionAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(true);
+    });
+
+    it('should return true if PRIVATE_KEY and ZKEVM_RPC_URL are configured', async () => {
+      (mockRuntime.getSetting as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'PRIVATE_KEY') return testPrivateKey;
+        if (key === 'ZKEVM_RPC_URL') return 'http://test-url.com';
+        return undefined;
+      });
+      const isValid = await sendL2TransactionAction.validate?.(mockRuntime, mockMemory, mockState);
+      expect(isValid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- LINK TO ISSUE OR TICKET -->
<!-- Placeholder: User to fill in if specific ticket/issue links exist. Context: Implementation of Get L1/L2 Exit Roots, Estimate Transaction zkCounters, and Send L2 Transaction (ETH Transfer) for plugin-polygon-zkevm. -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->
<!-- Placeholder: User to assess. Generally low if existing functionality is untouched and new features are well-tested. Potential risks could involve interactions with external APIs (Alchemy/RPC) or private key handling for the send transaction action if not configured correctly. -->

# Background

## What does this PR do?

This PR introduces three new actions to the `plugin-polygon-zkevm` ElizaOS plugin:

1.  **`GET_EXIT_ROOTS`**: Fetches the current L1 (mainnet) and L2 (rollup) exit root hashes from the Polygon zkEVM network. It uses Alchemy's `zkevm_getBatchByNumber` or a generic JSON-RPC fallback.
2.  **`ESTIMATE_TRANSACTION_ZK_COUNTER`**: Retrieves the next zk-nonce (zkCounter) for a given Ethereum address on Polygon zkEVM. It uses Alchemy's `eth_getTransactionCount` or a generic JSON-RPC fallback.
3.  **`SEND_L2_TRANSACTION`**: Allows sending native ETH (L2) transactions on Polygon zkEVM. It takes parameters for the recipient, value, and optional gas settings, using a provided private key to sign the transaction. It supports Alchemy's `core.sendTransaction` (via `eth_sendRawTransaction`) or a generic JSON-RPC fallback (`eth_sendRawTransaction`).

Unit tests for these three actions are also included in the `packages/plugin-polygon-zkevm/tests/unit/` directory.

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->
Features (non-breaking change which adds functionality)

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->
My changes likely require a change to the project documentation to reflect the new actions available in the `plugin-polygon-zkevm` plugin, their parameters, and expected outputs.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

A reviewer can start by examining the new action files in `packages/plugin-polygon-zkevm/src/actions/`:
*   `getExitRoots.ts`
*   `estimateZkNonce.ts`
*   `sendL2Transaction.ts`

And their corresponding unit tests in `packages/plugin-polygon-zkevm/tests/unit/`:
*   `getExitRoots.test.ts`
*   `estimateZkNonce.test.ts`
*   `sendL2Transaction.test.ts`

Review the registration of these actions in `packages/plugin-polygon-zkevm/src/plugin.ts` and any related templates in `packages/plugin-polygon-zkevm/src/templates.ts`.

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->
Automated tests are acceptable (unit tests provided).

Manual testing was also performed by the user via the ElizaOS UI for each action:
*   `GET_EXIT_ROOTS`: Verified successful retrieval of L1 and L2 roots.
*   `ESTIMATE_TRANSACTION_ZK_COUNTER`: Verified successful retrieval of zkNonce for a test address.
*   `SEND_L2_TRANSACTION`: Verified successful ETH transfer on zkEVM, confirmed by transaction hash and UI feedback. Debugging steps included resolving BigInt serialization issues and ensuring legacy transaction types were used.

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->
<!-- User provided a screenshot confirming successful `SEND_L2_TRANSACTION` via UI: Image of transaction success message with hash, recipient, and amount. -->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/elizaOS and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->